### PR TITLE
Don't Use PAL60 on NTSC.

### DIFF
--- a/Source/Core/DolphinWX/ConfigMain.cpp
+++ b/Source/Core/DolphinWX/ConfigMain.cpp
@@ -322,6 +322,7 @@ void CConfigMain::InitializeGUILists()
 void CConfigMain::InitializeGUIValues()
 {
 	const SCoreStartupParameter& startup_params = SConfig::GetInstance().m_LocalCoreStartupParameter;
+	bool NTSC = SConfig::GetInstance().m_LocalCoreStartupParameter.bNTSC;
 
 	// General - Basic
 	CPUThread->SetValue(startup_params.bCPUThread);
@@ -440,7 +441,7 @@ void CConfigMain::InitializeGUIValues()
 
 	// Wii - Misc
 	WiiScreenSaver->SetValue(!!SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.SSV"));
-	WiiPAL60->SetValue(!!SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.E60"));
+	WiiPAL60->SetValue(!!SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.E60") && !NTSC);
 	WiiAspectRatio->SetSelection(SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.AR"));
 	WiiSystemLang->SetSelection(SConfig::GetInstance().m_SYSCONF->GetData<u8>("IPL.LNG"));
 


### PR DESCRIPTION
PAL60 should only be enabled if it's a PAL game because some NTSC games (e.g. Doc Louis's Punch-Out!!) have leftover code from the PAL version that looks at the PAL60 setting, and if it's enabled it attempts to load the NTSC game in PAL60 mode. This causes the game to hang on a black screen because NTSC games cannot display in PAL mode. This doesn't affect actual console because there is no PAL60 setting on an NTSC console.

This needs testing to see if it fixes these issues:
[Issue 7714](https://code.google.com/p/dolphin-emu/issues/detail?id=7714)
[Issue 7862](https://code.google.com/p/dolphin-emu/issues/detail?id=7862)
[Issue 8036](https://code.google.com/p/dolphin-emu/issues/detail?id=8036)

@Stevoisiak You should be able to remove your sentence saying PAL60 may not work for all games in PR #1808.

@Linktothepast You should be able to remove the notes in INI files about NTSC games not working with PAL60.
